### PR TITLE
[QOH-1543] add codespace cors instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ GET https://infra.devskills.app/api/accounting/accounts/0afd02d3-6c59-46e7-b7bc-
 
 <!--TASK_INSTRUCTIONS_END-->
 
+### Codespace CORS issue
+If you are using Codespace, you might encounter CORS related issue because the backend project's port is private by default. To resolve this, make the port public by running the following command inside the Codespace. Replace <PORT> with the actual port number your backend project is using.
+```
+gh codespace ports visibility <PORT>:public -c $CODESPACE_NAME
+```
+
 ## When you are done
 
 1. [Create a new Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) from the branch where you've committed your solution to the default branch of this repository. **Please do not merge the created Pull Request**.


### PR DESCRIPTION
It turns out we need to set the backend project's port to public in order for it to work smoothly in Codespace. For now added the additional instruction in the Readme file. 